### PR TITLE
Further optimized getGamesOwned and add support for images

### DIFF
--- a/app/GameAPIs/Achievement.php
+++ b/app/GameAPIs/Achievement.php
@@ -36,6 +36,12 @@ class Achievement
      */
     private $dateEarned;
 
+    /**
+     * URL string for the icon image of this achievement.
+     * @var string
+     */
+    private $iconImage;
+
     //============================ CONSTRUCTOR ============================
 
     /**
@@ -85,6 +91,24 @@ class Achievement
     public function getDateEarned(): string
     {
         return $this->dateEarned;
+    }
+
+    /**
+     * Get the URL for the icon image of this achievement.
+     * @return string
+     */
+    public function getIconImage(): string
+    {
+        return $this->iconImage;
+    }
+
+    /**
+     * Set the URL for the icon image of this achievement.
+     * @param string $iconImage
+     */
+    public function setIconImage(string $iconImage): void
+    {
+        $this->iconImage = $iconImage;
     }
 
     public function toString() : string

--- a/app/GameAPIs/GameObject.php
+++ b/app/GameAPIs/GameObject.php
@@ -47,6 +47,12 @@ class GameObject
      */
     private $releaseDate;
 
+    /**
+     * URL string for the cover image of the game.
+     * @var string
+     */
+    private $coverImage;
+
     //============================ CONSTRUCTOR ============================
 
     /**
@@ -106,6 +112,24 @@ class GameObject
     public function getReleaseDate(): string
     {
         return $this->releaseDate;
+    }
+
+    /**
+     * Get the URL string for the cover image of this game.
+     * @return string
+     */
+    public function getCoverImage(): string
+    {
+        return $this->coverImage;
+    }
+
+    /**
+     * Set the cover image URL for this game.
+     * @param string $url
+     */
+    public function setCoverImage(string $url): void
+    {
+        $this->coverImage = $url;
     }
 
     public function toString() : string

--- a/app/GameAPIs/SteamUser.php
+++ b/app/GameAPIs/SteamUser.php
@@ -36,6 +36,12 @@ class SteamUser
      */
     private $gameList;
 
+    /**
+     * URL string for the profile image of this Steam User.
+     * @var string
+     */
+    private $profileImage;
+
     //============================ CONSTRUCTOR ============================
 
     /**
@@ -99,6 +105,24 @@ class SteamUser
     public function getGameList(): GameList
     {
         return $this->gameList;
+    }
+
+    /**
+     * Get the URL string for the cover image.
+     * @return string
+     */
+    public function getProfileImage(): string
+    {
+        return $this->profileImage;
+    }
+
+    /**
+     * Set the URL string for the profile image of this Steam User.
+     * @param string $url
+     */
+    public function setProfileImage(string $url) : void
+    {
+        $this->profileImage = $url;
     }
 
     /**

--- a/resources/views/accounts/steamlinked.blade.php
+++ b/resources/views/accounts/steamlinked.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app');
+@extends('layouts.app')
 
 @section('content')
     <!-- This page converts the GET to a POST and posts the info to Accounts-->

--- a/resources/views/steamapitests.blade.php
+++ b/resources/views/steamapitests.blade.php
@@ -7,11 +7,14 @@
     $steamID = session('steamData')['steamID'];
     // Get SteamUser Test:
     $steamUser = $connector->getSteamUser($steamID);
+    $profileImage = $steamUser->getProfileImage();
     // Load game information using hardcoded ids
     $gameObject1 = $connector->getGameInfo('620');
     $gameStr1 = $gameObject1->toString();
+    $gameImage1 = $gameObject1->getCoverImage();
     $gameObject2 = $connector->getGameInfo('638970');
     $gameStr2 = $gameObject2->toString();
+    $gameImage2 = $gameObject2->getCoverImage();
     // Get owned games for user with id 76561198962880722
     //$gameList = $connector->getGamesOwned($steamID);
     // Load the achievements for the user and their first game
@@ -22,15 +25,18 @@
     $errorsStr = $connector->getErrorsString();
 ?>
 
-@extends('layouts.app');
+@extends('layouts.app')
 
 @section('content')
     <div class="container">
         <h1>Steam API Tests:</h1>
         <h2>Get Steam User Test:</h2>
+        <img src="<?php echo $profileImage; ?>" class="rounded-circle" alt="Profile Image" width="100" height="100">
         <p><?php echo $steamUser->toString(); ?></p>
         <h2>Load game information test:</h2>
+        <img src="<?php echo $gameImage1; ?>" class="rounded" alt="Game Image 1" width="230" height="107">
         <p><?php echo $gameStr1; ?></p>
+        <img src="<?php echo $gameImage2; ?>" class="rounded" alt="Game Image 2" width="230" height="107">
         <p><?php echo $gameStr2; ?></p>
         <h2>Get owned games test:</h2>
         <p><?php //echo $gameList->toString(); ?></p>

--- a/resources/views/steamlogin.blade.php
+++ b/resources/views/steamlogin.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app');
+@extends('layouts.app')
 
 @section('content')
     <div class="'container">


### PR DESCRIPTION
I further optimized the getGamesOwned functions. I also added support for images for Steam users, game objects, and achievement objects. The image is simply saved as a URL string in their corresponding objects. Look at the steamapitests view to see how these images are rendered.