### PR TITLE
Tweaked game covers on home page, removed NULL steam games from list

### DIFF
--- a/app/GameAPIs/SteamAPIConnector.php
+++ b/app/GameAPIs/SteamAPIConnector.php
@@ -507,7 +507,7 @@ class SteamAPIConnector implements GameAPIInterface
             $earned = $this->getBooleanValue($playerAchievement['achieved']);
             $dateEarned = $playerAchievement['unlocktime'];
             $dateEarned = $this->convertUnixEpochTimeToDate($dateEarned);
-            $iconImage = $gameAchievement['icon'];
+            $iconImage = $gameAchievement['icon'] ?? "/svg/default_image.png";
 
             // Create and add the Achievement object to the AchievementList object.
             $achievement = new Achievement($name, $description, $earned, $dateEarned);

--- a/app/GameAPIs/XboxAPIConnector.php
+++ b/app/GameAPIs/XboxAPIConnector.php
@@ -245,7 +245,7 @@ class XboxAPIConnector implements GameAPIInterface
         $date = $achievement['timeUnlocked'];
         $date = $this->changeDateFormat($date);
         $array['date_earned'] = $date;
-        $array['icon'] = $achievement['imageUnlocked'] ?? null;
+        $array['icon'] = $achievement['imageUnlocked'] ?? "/svg/default_image.png";
         return $array;
     }
     /**
@@ -262,7 +262,7 @@ class XboxAPIConnector implements GameAPIInterface
         $date = $achievement['progression']['timeUnlocked'];
         $date = $this->changeDateFormat($date);
         $array['date_earned'] = (string) $date;
-        $array['icon'] = $achievement['mediaAssets'][0]['url'] ?? null;
+        $array['icon'] = $achievement['mediaAssets'][0]['url'] ?? "/svg/default_image.png";
         return $array;
     }
     /**

--- a/app/Http/Controllers/GamesController.php
+++ b/app/Http/Controllers/GamesController.php
@@ -70,7 +70,7 @@ class GamesController extends Controller
             if(array_key_exists($game, $allGames)){
                 //Game already in database, skip
                 $dbgame = $allGames[$game];
-                if(Game::find($dbgame)->name == "NULL") {
+                if(Game::find($dbgame)->name == "NULL" or Game::find($dbgame)->cover_image == "/svg/default_image.png") {
                     $this->updateGame($game, $dbgame, $data['platform']);
                 }
             }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -35,7 +35,7 @@ class HomeController extends Controller
             $stmCounts = ['total'=>'0 / 0'];
         }else{
             $stmCounts = $this->countAchievements($stmAcc);
-            $stmGames = $stmAcc->plays->toArray();
+            $stmGames = $stmAcc->plays()->where('name','!=','NULL')->get()->toArray();
             $stmGames = $this->sortGamesArray($stmGames);
 
         }
@@ -45,7 +45,7 @@ class HomeController extends Controller
             $xblCounts = ['total'=>'0 / 0'];
         }else{
             $xblCounts = $this->countAchievements($xblAcc);
-            $xblGames = $xblAcc->plays->toArray();
+            $xblGames = $xblAcc->plays()->where('name','!=','NULL')->get()->toArray();
             $xblGames = $this->sortGamesArray($xblGames);
         }
 

--- a/resources/views/games/gamepage.blade.php
+++ b/resources/views/games/gamepage.blade.php
@@ -5,7 +5,7 @@
         <a href="{{route('home')}}"> <strong><-Back</strong> </a>
         <div class="row">
             <div class="col-6">
-                <img src="{{ $game->cover_image }}" class="rounded  mw-100 mh-100" style="height:300px; overflow: hidden" alt="Game Image">
+                <img src="{{ $game->cover_image }}" class="rounded  mw-100 mh-100" style="min-width:100px ;height:300px; overflow: hidden" alt="Game Image">
             </div>
             <div class="col-6">
                 <h2>{{ $game->name }}</h2>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -61,7 +61,11 @@
                                             @foreach($stm as $game)
 
                                                 <tr>
-                                                    <th><img src="{{$game['cover_image']}}" class="rounded  mw-100 mh-100" style="height:70px; overflow: hidden" alt="Game Image"></th>
+                                                    <th>
+                                                        <a href="{{route('gamepage',$game['id'])}}">
+                                                            <img src="{{$game['cover_image']}}" class="rounded  mw-100 mh-100" style="min-width:100px; width:150px; overflow: hidden" alt="Game Image">
+                                                        </a>
+                                                    </th>
                                                     <th>
                                                         <a href="{{route('gamepage',$game['id'])}}">
                                                             {{ $game['name']}}
@@ -106,7 +110,11 @@
                                     @foreach($xbl as $game)
 
                                         <tr>
-                                            <th><img src="{{$game['cover_image']}}" class="rounded  mw-100 mh-100" style="height:100px; overflow: hidden" alt="Game Image"></th>
+                                            <th>
+                                                <a href="{{route('gamepage',$game['id'])}}">
+                                                    <img src="{{$game['cover_image']}}" class="rounded  mw-100 mh-100" style=" min-width: 65px;height:90px; overflow: hidden" alt="Game Image">
+                                                </a>
+                                            </th>
                                             <th>
                                                 <a href="{{route('gamepage',$game['id'])}}">
                                                     {{ $game['name']}}


### PR DESCRIPTION
-Reformatted game covers on home page to make them resize nicely
-Reformatted game covers on game pages to make them resize nicely
-Added link to game page to cover image
-Removed NULL steam games from home page. This may cause some achievements to not be included in the total counts. However, the games not included have no name, cover art or any other distinguishing identifiers. (Usually because they are no longer listed on Steam)